### PR TITLE
Add a signed Node Offer Document endpoint for discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# pyhypercycle-aim
+
+Python library for building **AIMs** (AI Modules) for the [HyperCycle](https://www.hypercycle.ai)
+network. An AIM is a small ASGI service that exposes one or more priced endpoints plus a
+self-describing `GET /manifest.json`. A HyperCycle node runs AIMs in numbered slots and a Node
+Manager handles payment and routing.
+
+## Quickstart
+
+Subclass one of the server helpers (`SimpleServer`, `SimpleQueue`, `AsyncQueue`), set a `manifest`,
+and decorate endpoints with `@aim_uri`:
+
+```python
+from pyhypercycle_aim import SimpleQueue, aim_uri, JSONResponseCORS
+
+class Example(SimpleQueue):
+    manifest = {"name": "Example", "short_name": "example", "version": "0.1",
+                "license": "Open", "author": "you"}
+
+    @aim_uri(uri="/model", methods=["POST"], endpoint_manifest={
+        "input_body": {"text": "<Text>"}, "output": "<JSON>", "currency": "USD",
+        "price_per_call": {"estimated_cost": 0.001, "min": 0, "max": 0.1},
+        "price_per_mb":  {"estimated_cost": 0, "min": 0, "max": 0},
+        "documentation": "Run the model.",
+        "example_calls": [{"body": {"text": "hi"}, "method": "POST", "query": "",
+                           "headers": "", "output": {"output": "hello"}}],
+    })
+    async def model(self, request):
+        data = await request.json()
+        return JSONResponseCORS({"output": data["text"].upper()})
+
+Example().run(uvicorn_kwargs={"host": "0.0.0.0", "port": 4000})
+```
+
+This automatically serves `GET /manifest.json` describing the AIM and its per-endpoint pricing.
+Send a `cost_only` header to any endpoint to get a `{min, max, estimated_cost, currency}` quote
+without doing the work.
+
+## Node Offer Document (discovery)
+
+Every server also serves a **signed Node Offer Document** at:
+
+```
+GET /.well-known/hypercycle/offers.json
+```
+
+`/manifest.json` describes *one AIM*. The offer document describes *this node* — which AIMs it runs,
+on what hardware, at what price — in one place that a discovery service or another agent can fetch to
+answer **"where can I run AIM X, and for how much?"**. It is **signed with the node's Ethereum key**,
+so any consumer can re-fetch it from the node and verify it independently; an index that caches it can
+never forge or alter a price. The node stays the source of truth.
+
+```jsonc
+{
+  "node": { "id": "0x…", "endpoint": "https://node.example:4000", "region": "eu-west",
+            "license_level": 4 },
+  "capabilities": { "gpus": 2, "gpu_model": "RTX 3090", "vram_gb": 48, "ram_gb": 128,
+                    "cpu": "Ryzen 9 5950X", "bandwidth_mbps": 1000 },
+  "aims": [ { "short_name": "example", "version": "0.1", "uri": "/model",
+              "price_per_call": { "estimated_cost": 0.001, "min": 0, "max": 0.1 },
+              "price_per_mb":   { "estimated_cost": 0, "min": 0, "max": 0 },
+              "currency": "USD", "settles_in": [] } ],
+  "issued_at": "2026-06-20T20:00:00Z",
+  "signature": "0x…"        // EIP-191 personal_sign over the doc minus this field
+}
+```
+
+### Configuration
+
+The `aims` block is built automatically from each endpoint's manifest pricing — you don't repeat it.
+Provide node identity, specs, and a signing key via **environment variables**:
+
+| Variable | Meaning |
+|---|---|
+| `HYPC_NODE_ID` | node's wallet/identity address (auto-filled from the key if a private key is set) |
+| `HYPC_NODE_ENDPOINT` | publicly reachable base URL of the node |
+| `HYPC_NODE_REGION` | free-text region, e.g. `eu-west` |
+| `HYPC_NODE_LICENSE_LEVEL` | integer license level |
+| `HYPC_NODE_PRIVATE_KEY` | Ethereum private key used to **sign** the document |
+| `HYPC_NODE_CAPABILITIES` | JSON object of self-declared hardware specs |
+
+…or by setting attributes on your server class: `capabilities`, `node_id`, `node_endpoint`,
+`node_region`, `license_level`, `node_private_key`.
+
+If no private key is configured the document is still served, just **unsigned** (`signature` omitted).
+Set `serve_offer_document = False` on your server to disable the endpoint entirely.
+
+### Verifying (consumer / indexer side)
+
+```python
+from pyhypercycle_aim.offers import verify_offer_document
+import httpx
+
+doc = httpx.get("https://node.example:4000/.well-known/hypercycle/offers.json").json()
+assert verify_offer_document(doc)   # True iff signed by node.id and untampered
+```
+
+Signing/verification use `eth_account` (already pulled in by the `web3` dependency).

--- a/pyhypercycle_aim/__init__.py
+++ b/pyhypercycle_aim/__init__.py
@@ -1,5 +1,6 @@
 from pyhypercycle_aim.exceptions import *
 from pyhypercycle_aim.util import *
+from pyhypercycle_aim.offers import *
 from pyhypercycle_aim.servers import *
 from pyhypercycle_aim.subscription import *
 from pyhypercycle_aim.storage import *

--- a/pyhypercycle_aim/offers.py
+++ b/pyhypercycle_aim/offers.py
@@ -1,0 +1,197 @@
+"""Node Offer Document — a node's signed, self-describing advertisement.
+
+A HyperCycle node already serves a ``/manifest.json`` per AIM describing *what it
+does* and *what it costs*. What the network has never had is a single, **signed**
+document at the node saying *"this node runs these AIMs, on this hardware, at these
+prices"* — the thing a discovery service (or another agent) needs to answer
+"where can I run AIM X, and for how much?".
+
+This module adds that as an OPTIONAL, standard endpoint:
+
+    GET /.well-known/hypercycle/offers.json
+
+The document is assembled from the AIM's own manifest (so prices stay in one
+place) plus an optional operator-declared ``capabilities`` block, and is **signed
+with the node's Ethereum key** (the same key the node already uses for payments /
+``AIM ProtocolV2``). Because it's signed, any consumer can re-fetch it straight
+from the node and verify it independently — so an index that caches it can never
+forge or alter a price. The node stays the source of truth; indexes are just
+caches. Serving it is opt-out (``serve_offer_document = False``); signing is
+automatic when a key is configured and a no-op otherwise.
+
+Signing uses ``eth_account`` (already available via the ``web3`` dependency); if
+it cannot be imported the document is still served, just unsigned.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+from starlette.routing import Route
+
+from pyhypercycle_aim.util import JSONResponseCORS
+
+try:  # eth_account ships with web3 (a declared dependency); degrade if absent
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+    _ETH_OK = True
+except Exception:  # pragma: no cover - only when web3/eth_account missing
+    _ETH_OK = False
+
+WELL_KNOWN_PATH = "/.well-known/hypercycle/offers.json"
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no server state) — also usable by indexers/consumers.
+# --------------------------------------------------------------------------- #
+def canonical(doc: dict) -> str:
+    """Canonical serialization that gets signed/verified.
+
+    The ``signature`` field is excluded; keys are sorted and separators are
+    compact so the sender and any verifier produce byte-identical input.
+    """
+    body = {k: v for k, v in doc.items() if k != "signature"}
+    return json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def build_offer_document(manifest_json: dict, *, node_id: str = "", endpoint: str = "",
+                         region: str = "", license_level=None, capabilities: dict | None = None,
+                         issued_at: str | None = None) -> dict:
+    """Build an (unsigned) offer document from an AIM ``manifest.json`` dict.
+
+    Each manifest endpoint becomes one priced offer for this AIM's ``short_name``.
+    """
+    short_name = manifest_json.get("short_name") or manifest_json.get("name") or ""
+    version = manifest_json.get("version") or ""
+    aims = []
+    for ep in (manifest_json.get("endpoints") or []):
+        aims.append({
+            "short_name": short_name,
+            "version": version,
+            "uri": ep.get("uri") or "/",
+            "price_per_call": ep.get("price_per_call") or {},
+            "price_per_mb": ep.get("price_per_mb") or {},
+            "currency": ep.get("currency") or "",
+            "settles_in": ep.get("settles_in") or [],
+        })
+    node = {"id": node_id or "", "endpoint": endpoint or ""}
+    if region:
+        node["region"] = region
+    if license_level is not None:
+        node["license_level"] = license_level
+    doc = {
+        "node": node,
+        "capabilities": capabilities or {},
+        "aims": aims,
+        "issued_at": issued_at or datetime.now(timezone.utc).isoformat(),
+    }
+    return doc
+
+
+def sign_offer_document(doc: dict, private_key: str) -> dict:
+    """Return a copy of ``doc`` with a ``signature`` (EIP-191 personal_sign).
+
+    If ``node.id`` is empty it is filled in from the key's address. Raises if
+    ``eth_account`` is unavailable so the caller can decide how to handle it.
+    """
+    if not _ETH_OK:
+        raise RuntimeError("eth_account not available (install web3) — cannot sign offer document")
+    acct = Account.from_key(private_key)
+    doc = dict(doc)
+    node = dict(doc.get("node") or {})
+    if not node.get("id"):
+        node["id"] = acct.address.lower()
+    doc["node"] = node
+    signed = acct.sign_message(encode_defunct(text=canonical(doc)))
+    doc["signature"] = signed.signature.hex()
+    return doc
+
+
+def verify_offer_document(doc: dict) -> bool:
+    """True iff ``doc.signature`` is a valid signature by ``doc.node.id``."""
+    node_id = ((doc.get("node") or {}).get("id") or "").lower()
+    sig = doc.get("signature")
+    if not (_ETH_OK and node_id and sig):
+        return False
+    try:
+        recovered = Account.recover_message(encode_defunct(text=canonical(doc)), signature=sig)
+        return recovered.lower() == node_id
+    except Exception:
+        return False
+
+
+def _capabilities_from_env() -> dict:
+    raw = os.environ.get("HYPC_NODE_CAPABILITIES", "")
+    if not raw:
+        return {}
+    try:
+        v = json.loads(raw)
+        return v if isinstance(v, dict) else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+def node_config_from_env() -> dict:
+    """Operator-supplied node identity/specs, read from environment variables.
+
+    HYPC_NODE_ID, HYPC_NODE_ENDPOINT, HYPC_NODE_REGION, HYPC_NODE_LICENSE_LEVEL,
+    HYPC_NODE_PRIVATE_KEY, HYPC_NODE_CAPABILITIES (JSON object).
+    """
+    lvl = os.environ.get("HYPC_NODE_LICENSE_LEVEL")
+    return {
+        "node_id": os.environ.get("HYPC_NODE_ID", ""),
+        "endpoint": os.environ.get("HYPC_NODE_ENDPOINT", ""),
+        "region": os.environ.get("HYPC_NODE_REGION", ""),
+        "license_level": int(lvl) if (lvl or "").isdigit() else None,
+        "private_key": os.environ.get("HYPC_NODE_PRIVATE_KEY", ""),
+        "capabilities": _capabilities_from_env(),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Mixin wired into the server base class.
+# --------------------------------------------------------------------------- #
+class OfferDocumentMixin:
+    """Adds a signed ``/.well-known/hypercycle/offers.json`` endpoint.
+
+    Configure via env vars (see :func:`node_config_from_env`) or by setting any of
+    these attributes on your server: ``capabilities`` (dict), ``node_id``,
+    ``node_endpoint``, ``node_region``, ``license_level``, ``node_private_key``.
+    Set ``serve_offer_document = False`` to opt out entirely.
+    """
+    serve_offer_document = True
+
+    def build_offer_document(self) -> dict:
+        cfg = node_config_from_env()
+        license_level = getattr(self, "license_level", None)
+        if license_level is None:
+            license_level = cfg["license_level"]
+        doc = build_offer_document(
+            getattr(self, "manifest_json", {}) or {},
+            node_id=getattr(self, "node_id", "") or cfg["node_id"],
+            endpoint=getattr(self, "node_endpoint", "") or cfg["endpoint"],
+            region=getattr(self, "node_region", "") or cfg["region"],
+            license_level=license_level,
+            capabilities=getattr(self, "capabilities", None) or cfg["capabilities"],
+        )
+        private_key = getattr(self, "node_private_key", "") or cfg["private_key"]
+        if private_key:
+            try:
+                doc = sign_offer_document(doc, private_key)
+            except Exception as exc:  # never block startup over signing
+                print(f"[offers] offer document left unsigned: {exc}")
+        return doc
+
+    def _register_offer_route(self, routes) -> None:
+        """Append the offers route unless opted out or already overridden."""
+        if not getattr(self, "serve_offer_document", True):
+            return
+        if any(getattr(r, "path", None) == WELL_KNOWN_PATH for r in routes):
+            return
+        self.offer_document_json = self.build_offer_document()
+        routes.append(Route(
+            WELL_KNOWN_PATH,
+            lambda *args, **kwargs: JSONResponseCORS(self.offer_document_json),
+            methods=["GET"],
+        ))

--- a/pyhypercycle_aim/servers.py
+++ b/pyhypercycle_aim/servers.py
@@ -4,11 +4,12 @@ import time
 import uvicorn
 from pyhypercycle_aim.util import to_async, JSONResponseCORS, default_exception_handlers, \
     aim_uri
+from pyhypercycle_aim.offers import OfferDocumentMixin
 from starlette.applications import Starlette
 from starlette.routing import Route, WebSocketRoute
 
 
-class BaseServer:
+class BaseServer(OfferDocumentMixin):
     def get_user_address(self, request):
         return request.headers.get("hypc_user", None)
 
@@ -56,9 +57,13 @@ class SimpleServer(BaseServer):
         self.manifest_json['endpoints'] = endpoints_manifest
         
         if has_manifest_override is False:
-            routes.append(Route("/manifest.json", 
+            routes.append(Route("/manifest.json",
                                 lambda *args, **kwargs: JSONResponseCORS(self.manifest_json),
                                 methods=["GET"]))
+
+        # Signed node Offer Document at /.well-known/hypercycle/offers.json
+        # (opt out with `serve_offer_document = False`). See offers.py.
+        self._register_offer_route(routes)
 
         self.job_queue = []
         self.queue_counter = 0
@@ -117,9 +122,13 @@ class SimpleQueue(BaseServer):
         self.manifest_json['endpoints'] = endpoints_manifest
         
         if has_manifest_override is False:
-            routes.append(Route("/manifest.json", 
+            routes.append(Route("/manifest.json",
                                 lambda *args, **kwargs: JSONResponseCORS(self.manifest_json),
                                 methods=["GET"]))
+
+        # Signed node Offer Document at /.well-known/hypercycle/offers.json
+        # (opt out with `serve_offer_document = False`). See offers.py.
+        self._register_offer_route(routes)
 
         self.job_queue = []
         self.queue_counter = 0
@@ -242,9 +251,13 @@ class AsyncQueue(BaseServer):
             self.manifest_json['endpoints'] = new_endpoints
                     
         if has_manifest_override is False:
-            routes.append(Route("/manifest.json", 
+            routes.append(Route("/manifest.json",
                                 lambda *args, **kwargs: JSONResponseCORS(self.manifest_json),
                                 methods=["GET"]))
+
+        # Signed node Offer Document at /.well-known/hypercycle/offers.json
+        # (opt out with `serve_offer_document = False`). See offers.py.
+        self._register_offer_route(routes)
 
         self.job_queue = []
         self.queue_counter = 0

--- a/tests/test_offers.py
+++ b/tests/test_offers.py
@@ -1,0 +1,101 @@
+"""Tests for the node Offer Document (pyhypercycle_aim.offers)."""
+import json
+
+from eth_account import Account
+
+from pyhypercycle_aim.offers import (
+    build_offer_document,
+    canonical,
+    sign_offer_document,
+    verify_offer_document,
+    OfferDocumentMixin,
+)
+
+MANIFEST = {
+    "name": "Example",
+    "short_name": "example",
+    "version": "0.1",
+    "endpoints": [{
+        "uri": "/model",
+        "currency": "USD",
+        "price_per_call": {"estimated_cost": 0.001, "min": 0, "max": 0.1},
+        "price_per_mb": {"estimated_cost": 0, "min": 0, "max": 0},
+    }],
+}
+
+
+def test_build_from_manifest():
+    doc = build_offer_document(MANIFEST, node_id="0xabc", endpoint="http://n:4000",
+                               capabilities={"gpus": 1})
+    assert doc["node"]["id"] == "0xabc"
+    assert doc["capabilities"] == {"gpus": 1}
+    assert len(doc["aims"]) == 1
+    o = doc["aims"][0]
+    assert o["short_name"] == "example"
+    assert o["version"] == "0.1"
+    assert o["uri"] == "/model"
+    assert o["price_per_call"]["estimated_cost"] == 0.001
+    assert "issued_at" in doc
+
+
+def test_canonical_excludes_signature_and_is_stable():
+    doc = {"b": 2, "a": 1, "signature": "0xdead"}
+    assert canonical(doc) == '{"a":1,"b":2}'
+
+
+def test_sign_and_verify_roundtrip():
+    acct = Account.create()
+    doc = build_offer_document(MANIFEST, endpoint="http://n:4000")
+    signed = sign_offer_document(doc, acct.key.hex())
+    # node.id is filled in from the key when omitted
+    assert signed["node"]["id"] == acct.address.lower()
+    assert verify_offer_document(signed) is True
+
+
+def test_tampered_price_fails_verification():
+    acct = Account.create()
+    signed = sign_offer_document(build_offer_document(MANIFEST), acct.key.hex())
+    assert verify_offer_document(signed) is True
+    # an index that alters the price can't keep the signature valid
+    signed["aims"][0]["price_per_call"]["estimated_cost"] = 999
+    assert verify_offer_document(signed) is False
+
+
+def test_tampered_node_id_fails_verification():
+    acct = Account.create()
+    signed = sign_offer_document(build_offer_document(MANIFEST), acct.key.hex())
+    signed["node"]["id"] = "0x0000000000000000000000000000000000000000"
+    assert verify_offer_document(signed) is False
+
+
+def test_unsigned_document_does_not_verify():
+    doc = build_offer_document(MANIFEST, node_id="0xabc")
+    assert "signature" not in doc
+    assert verify_offer_document(doc) is False
+
+
+def test_mixin_opt_out():
+    class S(OfferDocumentMixin):
+        serve_offer_document = False
+        manifest_json = MANIFEST
+    routes = []
+    S()._register_offer_route(routes)
+    assert routes == []
+
+
+def test_mixin_registers_route_and_signs_from_attr():
+    acct = Account.create()
+
+    class S(OfferDocumentMixin):
+        manifest_json = MANIFEST
+        capabilities = {"gpus": 2, "gpu_model": "RTX 3090"}
+        node_private_key = acct.key.hex()
+        node_endpoint = "http://n:4000"
+
+    s = S()
+    routes = []
+    s._register_offer_route(routes)
+    assert len(routes) == 1
+    assert routes[0].path == "/.well-known/hypercycle/offers.json"
+    assert verify_offer_document(s.offer_document_json) is True
+    assert s.offer_document_json["capabilities"]["gpu_model"] == "RTX 3090"


### PR DESCRIPTION
# PR: Add a signed Node Offer Document endpoint for discovery

**Target:** `hypercycle-development/pyhypercycle-aim`
**Branch:** `feat/node-offer-document`

## What & why

HyperCycle nodes already serve a `GET /manifest.json` per AIM (what it does, what it costs). What the
network has never had is a single, **signed** document at the node that says *"this node runs these
AIMs, on this hardware, at these prices."* That's exactly the data a discovery service — or another
agent — needs to answer **"where can I run AIM X, and for how much?"**

This PR adds that as an **optional, standard** endpoint every server serves:

```
GET /.well-known/hypercycle/offers.json
```

The document is **signed with the node's Ethereum key** (the same key kind nodes already use for
payments / AIM ProtocolV2). Because it's signed, any consumer can re-fetch it directly from the node
and verify it independently — so an index that *caches* it can never forge or alter a price. **The node
stays the source of truth; indexes are just caches.** This fills the "IoAI Registry / Network Node
Marketplace" slot the whitepaper names but never defined, without making any single indexer a required
dependency.

## Design

- The `aims` block is assembled from each endpoint's existing manifest pricing (`price_per_call`,
  `price_per_mb`, `currency`) — **no duplication** of price data.
- An optional operator-declared `capabilities` block carries hardware specs (gpus, vram, cpu, ram,
  bandwidth, …) that the manifest doesn't standardize.
- Signing/verification use `eth_account`, which is **already pulled in by the existing `web3`
  dependency** — so this PR adds **zero new dependencies**.
- **Opt-out:** set `serve_offer_document = False` on your server.
- **Graceful:** if no signing key is configured, the document is still served, just unsigned.

Example:
```jsonc
{
  "node": { "id": "0x…", "endpoint": "https://node.example:4000", "region": "eu-west",
            "license_level": 4 },
  "capabilities": { "gpus": 2, "gpu_model": "RTX 3090", "vram_gb": 48 },
  "aims": [ { "short_name": "example", "version": "0.1", "uri": "/model",
              "price_per_call": { "estimated_cost": 0.001, "min": 0, "max": 0.1 },
              "price_per_mb": { "estimated_cost": 0, "min": 0, "max": 0 },
              "currency": "USD", "settles_in": [] } ],
  "issued_at": "2026-06-20T20:00:00Z",
  "signature": "0x…"
}
```

## Configuration

Via env vars (`HYPC_NODE_ID`, `HYPC_NODE_ENDPOINT`, `HYPC_NODE_REGION`, `HYPC_NODE_LICENSE_LEVEL`,
`HYPC_NODE_PRIVATE_KEY`, `HYPC_NODE_CAPABILITIES` as JSON) or by setting server-class attributes
(`capabilities`, `node_id`, `node_endpoint`, `node_region`, `license_level`, `node_private_key`).

## Changes

| File | Change |
|---|---|
| `pyhypercycle_aim/offers.py` (new) | `build_offer_document` / `sign_offer_document` / `verify_offer_document` / `canonical` helpers + `OfferDocumentMixin` |
| `pyhypercycle_aim/servers.py` | `BaseServer` inherits the mixin; each `run()` registers the route (parallel to the existing `/manifest.json` route) |
| `pyhypercycle_aim/__init__.py` | export `offers` |
| `tests/test_offers.py` (new) | 8 tests: build/sign/verify round-trip, tamper rejection (price & id), unsigned, opt-out, mixin route registration |
| `README.md` | quickstart + Offer Document docs (repo had no README) |

## Backwards compatibility

Purely additive. Existing AIMs gain the new endpoint automatically; nothing else changes. Servers that
define their own `/.well-known/hypercycle/offers.json` route are left untouched (the registrar skips a
path that's already present), and `serve_offer_document = False` disables it.

## Testing

`pytest tests/test_offers.py` → 8 passed. Also validated end-to-end: a `SimpleServer` subclass serves a
`200` signed document over HTTP whose signature verifies and breaks under tampering.
